### PR TITLE
Fix API documentation response status code from 204 to 200

### DIFF
--- a/src/routes/api-docs.ts
+++ b/src/routes/api-docs.ts
@@ -88,7 +88,7 @@
  *        required: true
  *        description: ID do post
  *     responses:
- *       204:
+ *       200:
  *         description: Sucesso
  *         content:
  *           application/json:


### PR DESCRIPTION
This pull request includes a small change to the `src/routes/api-docs.ts` file. The change updates the response code for a successful request from 204 to 200.